### PR TITLE
Fix for bug where needed count is sometimes incorrect in jobs sidebar 

### DIFF
--- a/signup/models.py
+++ b/signup/models.py
@@ -76,7 +76,7 @@ class Coordinator(models.Model):
     url = URLField()
 
 class Job(models.Model):
-    '''An individual job''' 
+    '''An individual job (volunteer shift) in a role''' 
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     source = ForeignKey(Source, on_delete=models.CASCADE)
@@ -116,4 +116,5 @@ class Volunteer(models.Model):
     # --- 
     
     comment = TextField()
+
    

--- a/signup/templates/signup/jobpage.html
+++ b/signup/templates/signup/jobpage.html
@@ -19,7 +19,7 @@
 						<li class="list-group-item">
 							<img title="{{r.alt}}" src="{% static r.pic %}" height=20></img>
 							<a href="{% url "jobs" title=r.role.source.pk %}">{{r.role.source.pk}}</a>
-							<br/><small>{{r.needed}} volunteer(s) needed</small>
+							<br/><small>{{r.needed}} volunteer(s) needed </small>
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -48,7 +48,7 @@
 									<a href="{% url "jobs" title=r.role.source.pk %}">
 										<img src="{% static r.pic %}" height=15></img>
 										{{r.role.source.pk}}
-										<br/><small>{{r.needed}} volunteer(s) needed</small>
+										<br/><small>{{r.needed}} volunteer(s) needed </small>
 									</a>
 								</li>
 							{% endif %}

--- a/signup/views/jobs.py
+++ b/signup/views/jobs.py
@@ -56,7 +56,7 @@ def getNavData() :
             jobcount = 0
             
         personcount = Volunteer.objects.filter(source__exact=role.source.pk).count()
-        ent['needed'] = jobcount - personcount
+        ent['needed'] = jobcount - personcount # sometimes incorrect, theories above
         ent['jobs'] = jobcount
         ent['status'] = role.status
         ent.update(badgeFor(role, jobcount, personcount))
@@ -189,13 +189,13 @@ def jobs(request, title):
     status = get_status(role, needed_staff, total_staff)
 
     template_values = {
-        'navdata': navdata,
+        'navdata': navdata, # .needed is sometimes incorrect
         'role': role,
         'coordinators' : coordinators,
         'jobs' : jobstaff,
         'user' : request.user,
-        'total' : total_staff, 
-        'needed' : needed_staff,
+        'total' : total_staff,  # correct
+        'needed' : needed_staff, # correct
         'status' : status,
         'coordinator_of' : is_coordinator,
         'next' : next_job,

--- a/signup/views/react.py
+++ b/signup/views/react.py
@@ -91,10 +91,11 @@ def get_job_summary(request) :
         jobcount = Job.objects.filter(source__exact=role.source.pk).aggregate(Sum('needs'))['needs__sum']
         if jobcount is None : 
             jobcount = 0            
+        # may need to update personcount here like in getNavData()
         personcount = Volunteer.objects.filter(source__exact=role.source.pk).count()
         navdata.append({
             'role': role.pk, 
-            'needed': jobcount - personcount, 
+            'needed': jobcount - personcount,
             'jobs': jobcount, 
             'status': role.status,
             'is_coordinator': is_coordinator_of(request.user, role.source)          


### PR DESCRIPTION
When looking at jobs/<title> pages, the left sidebar contains a list of all jobs each with a "needed" count of how many volunteer shifts still need to be filled in that job.  Sometimes this "needed" number is incorrect. 